### PR TITLE
Refresh: Hugo build + GA4 + template/link fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,13 @@
 .DS_Store
+
+# Hugo build output
+public/
+resources/_gen/
+.hugo_build.lock
+
+# OS/editor noise
+*.log
+
+# Node (if you add an asset pipeline later)
+node_modules/
+

--- a/config.toml
+++ b/config.toml
@@ -3,7 +3,9 @@ baseURL = "https://www.robertkevinphillips.com"
 title = "Robert Phillips Portfolio"
 theme = "airspace-hugo"
 # post pagination
-paginate = "4"
+
+[pagination]
+pagerSize = 4
 # post excerpt
 summaryLength = "30"
 # disqus short name

--- a/config.toml
+++ b/config.toml
@@ -63,10 +63,15 @@ location = "Athens, Georgia"
 # contact form action
 # contact form works with : https://formspree.io
 contact_form_action = "https://formspree.io/mgendwql" 
-# Google Analitycs
-google_analitycs_id = "" # Your ID# search
+# Google Analytics (GA4 Measurement ID like G-XXXXXXX)
+google_analytics_id = ""
 # multi-author support (if set to true, you must use an Array in the author field)
 multi_author = false
+
+[markup]
+	[markup.goldmark]
+		[markup.goldmark.renderer]
+			unsafe = true
 
 # Preloader
 [params.preloader]
@@ -82,7 +87,7 @@ link = "contact"
 # google map
 [params.gmap]
 enable = false
-gmap_api = "https://maps.googleapis.com/maps/api/js?key=AIzaSyCcABaamniA6OL5YvYSpB3pFMNrXwXnLwU&libraries=places"
+gmap_api = ""
 map_latitude = "51.5223477"
 map_longitude = "-0.1622023"
 map_marker = "images/marker.png"
@@ -108,6 +113,7 @@ link = "https://www.github.com/rpdecks"
 [[params.social]]
 icon = "ion-ios-email" 
 link = "mailto:rpdecks@gmail.com"
+
 ################################ English Language ########################
 
 [Languages.en]

--- a/content/english/blog/blog-post-3.md
+++ b/content/english/blog/blog-post-3.md
@@ -23,11 +23,11 @@ type: "post"
 
 These two videos did a great job explaining an API in simple terms.  
 **What is an API?**  
-[![waiter image](https://img.youtube.com/vi/s7wmiS2mSXY/0.jpg)](http://www.youtube.com/watch?v=s7wmiS2mSXY)
+[![waiter image](https://img.youtube.com/vi/s7wmiS2mSXY/0.jpg)](https://www.youtube.com/watch?v=s7wmiS2mSXY)
 
 
 **What Are APIs? — Simply Explained**  
-[![API image](https://img.youtube.com/vi/OVvTv9Hy91Q/0.jpg)](http://www.youtube.com/watch?v=OVvTv9Hy91Q)
+[![API image](https://img.youtube.com/vi/OVvTv9Hy91Q/0.jpg)](https://www.youtube.com/watch?v=OVvTv9Hy91Q)
 
 I appreciate the comparison of the API to the waiter in a restaurant. On one end there is a kitchen handling and processing raw elements and on the other end, a consumer… well, consuming. The waiter (i.e. API) handles the interface between the two so that the consumer can get, meaningfully, what he/she wanted from the kitchen, without all the messy behind the curtain detail, procedure, and process. Watch the videos, they do much better than me explaining… and the pictures help a lot too.  
 

--- a/content/english/project/natours.md
+++ b/content/english/project/natours.md
@@ -19,7 +19,7 @@ information:
     info : "September 2020"
 ---
 
-## [Natours Website](www.natours-rkp.netlify.app)
+## [Natours Website](https://natours-rkp.netlify.app)
 
 Sample website for a touring company that demonstrates modern responsive design using HTML / CSS.  
 

--- a/content/english/project/nexter.md
+++ b/content/english/project/nexter.md
@@ -19,7 +19,7 @@ information:
     info : "June 2020"
 ---
 
-## [ Nexter ](www.nexter-rkp.netlify.app)
+## [ Nexter ](https://nexter-rkp.netlify.app)
 
 Sample website for a real estate company that demonstrates modern responsive design using HTML / CSS Grid.  
 

--- a/content/english/project/trillo.md
+++ b/content/english/project/trillo.md
@@ -19,7 +19,7 @@ information:
     info : "September 2020"
 ---
 
-## [Trillo Website](www.trillo-rkp.netlify.app)
+## [Trillo Website](https://trillo-rkp.netlify.app)
 
 Sample website for a touring company that demonstrates modern responsive design using HTML / CSS / Flexbox.
 

--- a/layouts/_default/_markup/render-image.html
+++ b/layouts/_default/_markup/render-image.html
@@ -1,1 +1,1 @@
-<a href="{{ .Destination | safeURL }}"{{ with .Title}} title="{{ . }}"{{ end }}{{ if strings.HasPrefix .Destination "https" }} target="_blank"{{ end }}>{{ .Text }}</a>
+<img src="{{ .Destination | safeURL }}" alt="{{ with .Text }}{{ . }}{{ else }}{{ with .Title }}{{ . }}{{ else }}{{ end }}{{ end }}" loading="lazy">

--- a/layouts/_default/_markup/render-link.html
+++ b/layouts/_default/_markup/render-link.html
@@ -1,1 +1,1 @@
-<a href="{{ .Destination | safeURL }}"{{ with .Title}} title="{{ . }}"{{ end }}{{ if strings.HasPrefix .Destination "https" }} target="_blank"{{ end }}>{{ .Text }}</a>
+<a href="{{ .Destination | safeURL }}"{{ with .Title}} title="{{ . }}"{{ end }}{{ if strings.HasPrefix .Destination "http" }} target="_blank" rel="noopener noreferrer"{{ end }}>{{ .Text }}</a>

--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -9,7 +9,7 @@
             {{ end }}
 					</ul>
 				</div>
-				<p class="copyright">{{ site.Params.copyright | markdownify }}</p>
+				<p class="copyright">{{ site.Copyright | markdownify }}</p>
 			</div>
 		</div>
 	</div>
@@ -29,14 +29,18 @@
 {{ $script := resources.Get "js/script.js" | minify}}
 <script src="{{ $script.Permalink }}"></script>
 
-<!-- google analitycs -->
-{{ with site.Params.google_analitycs_id }}
+<!-- Google Analytics (gtag.js) -->
+{{ $ga := "" }}
+{{ with site.Config.Services.GoogleAnalytics.ID }}{{ $ga = . }}{{ end }}
+{{ if not $ga }}{{ with site.Params.google_analytics_id }}{{ $ga = . }}{{ end }}{{ end }}
+{{ if not $ga }}{{ with site.Params.google_analitycs_id }}{{ $ga = . }}{{ end }}{{ end }}
+
+{{ with $ga }}
+<script async src="https://www.googletagmanager.com/gtag/js?id={{ . }}"></script>
 <script>
-  (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-  (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-  m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-  })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-  ga('create', '{{ . }}', 'auto');
-  ga('send', 'pageview');
+	window.dataLayer = window.dataLayer || [];
+	function gtag(){dataLayer.push(arguments);}
+	gtag('js', new Date());
+	gtag('config', '{{ . }}', { 'anonymize_ip': true });
 </script>
 {{ end }}

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -2,14 +2,13 @@
   <meta charset="utf-8">
   <title>{{ .Title }}</title>
 
-  <link href='/plugins/fontawesome/css/all.css' rel='stylesheet'>
-  <link href='https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.14.0/css/all.min.css'>
-
-  <meta property="og:title" content="Robert Phillips Portfolio" />
-  <meta property="og:image" content="images/landing-screenshot.png" />
+  <meta property="og:title" content="{{ .Title }}" />
+  <meta property="og:image" content="{{ "images/landing-screenshot.png" | absURL }}" />
+  <meta property="og:url" content="{{ .Permalink }}" />
+  <meta property="og:type" content="{{ if .IsHome }}website{{ else }}article{{ end }}" />
+  <link rel="canonical" href="{{ .Permalink }}">
 
   {{ "<!-- mobile responsive meta -->" | safeHTML }}
-  <meta name="viewport" content="width=device-width, initial-scale=1">
   <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1">
   <meta name="description" content="{{ with .Params.Description }}{{ . }}{{ else }}{{ with site.Params.description }}{{ . }}{{ end }}{{ end }}">
   {{ with site.Params.author }}<meta name="author" content="{{ . }}">{{ end }}

--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -36,7 +36,7 @@
               {{ end }}
 
               <!-- Language List -->
-              {{- if site.IsMultiLingual }}
+              {{- if hugo.IsMultilingual }}
               <li>
                 <select id="select-language" onchange="location = this.value;">
                   {{ $siteLanguages := site.Languages}}

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,6 +1,9 @@
 [build]
   publish = "public"
-  command = "hugo"
+  command = "hugo --gc --minify"
   
 [context.production.environment]
-  HUGO_VERSION = "0.73.0"
+  HUGO_VERSION = "0.121.2"
+  HUGO_ENV = "production"
+  HUGO_ENABLEGITINFO = "true"
+  HUGO_EXTENDED = "true"

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,9 +1,16 @@
 [build]
   publish = "public"
   command = "hugo --gc --minify"
-  
-[context.production.environment]
+
+[build.environment]
+  # Netlify UI currently warns about Node 12; set a modern LTS.
+  # (Hugo itself doesn't require Node, but Netlify tooling/agents may.)
+  NODE_VERSION = "22"
+
+  # Keep Hugo version consistent across production + previews.
   HUGO_VERSION = "0.121.2"
-  HUGO_ENV = "production"
   HUGO_ENABLEGITINFO = "true"
   HUGO_EXTENDED = "true"
+  
+[context.production.environment]
+  HUGO_ENV = "production"


### PR DESCRIPTION
This PR refreshes the Hugo portfolio site with a small set of safe modernization changes, split into focused commits.

Commits:
- chore: ignore Hugo build artifacts
- config: remove Maps key; enable Goldmark unsafe; add GA4 param
- fix: head metadata + Markdown render hooks
- feat: GA4 gtag snippet + copyright uses site.Copyright
- build: bump Hugo on Netlify (extended + production flags)
- content: fix broken external links

Notes:
- Maps API key removed from repo history going forward.
- Netlify now uses Hugo 0.121.2 (extended). If Netlify build fails, we may need to adjust env vars depending on their current support.
- Some project links still point to legacy Heroku apps; those likely need new URLs or an “archived” label.