### PR TITLE
Fix Netlify build: bump Hugo to 0.155.2

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -8,7 +8,8 @@
   NODE_VERSION = "22"
 
   # Keep Hugo version consistent across production + previews.
-  HUGO_VERSION = "0.121.2"
+  # Keep this aligned with local Hugo; needed for hugo.IsMultilingual and pagination.pagerSize.
+  HUGO_VERSION = "0.155.2"
   HUGO_ENABLEGITINFO = "true"
   HUGO_EXTENDED = "true"
   


### PR DESCRIPTION
Netlify production build was using Hugo 0.121.2, but the site now relies on Hugo features added later (e.g. hugo.IsMultilingual, pagination.pagerSize). This bumps HUGO_VERSION in netlify.toml to 0.155.2 to match local builds and fix Netlify build failures.